### PR TITLE
[Enh] Remove forge from Puppetfile

### DIFF
--- a/crmngr/controlrepository.py
+++ b/crmngr/controlrepository.py
@@ -136,8 +136,8 @@ class ControlRepository(Repository):
         self.git(['checkout', '--orphan', new_env])
         self.git(['reset', '--hard'])
 
-        with open(os.path.join(self._workdir, 'Puppetfile'), 'w') as puppetfile:
-            puppetfile.write("forge 'http://forge.puppetlabs.com'\n\n")
+        # create empty Puppetfile
+        open(os.path.join(self._workdir, 'Puppetfile'), 'a').close()
         self.git(['add', 'Puppetfile'])
         os.mkdir(os.path.join(self._workdir, 'manifests'))
         with open(os.path.join(self._workdir, 'manifests', 'site.pp'),
@@ -577,8 +577,6 @@ class ControlRepository(Repository):
                   'w') as puppetfile:
             LOG.debug('write new version of Puppetfile in environment %s',
                       environment.name)
-            # write file header
-            puppetfile.write("forge 'http://forge.puppetlabs.com'\n\n")
             # write module lines
             puppetfile.writelines(
                 ('{}\n'.format(line)


### PR DESCRIPTION
We can remove the forge directive from the puppetfile as forge.puppetlabs.com is the default
url.
This also allow us to provide custom forge url in r10k deploy (internal or artifactory
one).